### PR TITLE
Workaround to fix the issue #8

### DIFF
--- a/resources/trusted_certificate.rb
+++ b/resources/trusted_certificate.rb
@@ -39,7 +39,7 @@ action :create do
   end
 end
 
-action_class do
+action_class.class_eval do
   def certificate_path
     case node['platform_family']
     when 'debian'


### PR DESCRIPTION
### Description

This changes fixed the issue where certificate path is not recognised as method

### Issues Resolved

#8 

### Check List

- [x ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
