### PR TITLE
Creating certificate folder before deploying the file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manages adding certificates to the OS trust store'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.1.1'
+version '3.1.2'
 
 %w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon zlinux).each do |os|
   supports os

--- a/resources/trusted_certificate.rb
+++ b/resources/trusted_certificate.rb
@@ -28,6 +28,14 @@ action :create do
     action :nothing
   end
 
+  directory certificate_path do
+    recursive true
+    mode '755'
+    owner 'root'
+    group 'staff' if platform_family?('debian')
+    action :create
+  end
+
   file "#{certificate_path}/#{new_resource.certificate_name}.crt" do
     content new_resource.content
     owner 'root'


### PR DESCRIPTION
### Description

Creating the folder before the certificate is deployed.

### Issues Resolved

#10
