### PR TITLE
Enable installation of certs via URL or cookbook_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Adds a certificate to the operating system's trust store.
 
 #### properties
 
-- `content`: The contents of the cert to add
+- `content`: The contents of the cert to add.  This can be specfied as inline content, a URL to a remote file, or a cookbook_file included in a wrapper cookbook.
 - `certificate_name`: The filename of the cert
 
 #### actions
@@ -43,12 +43,34 @@ Adds a certificate to the operating system's trust store.
 
 #### example
 
+Create certificate from inline content:
+
 ```ruby
 trusted_certificate 'my_corp' do
   action :create
   content 'THIS_WOULD_BE_THE_WHOLE_CERT_CONTENTS'
 end
 ```
+
+Download from a remote location:
+
+```ruby
+trusted_certificate 'my_corp_remote' do
+  action :create
+  content 'http://www.example.com/my_corp_remote.crt'
+end
+```
+
+Create cert from file included in a wrapper cookbook:
+
+```ruby
+trusted_certificate 'my_corp_cert_wrapper' do
+  action :create
+  content 'cookbook_file://my_trusted_certs::my_corp_cert.crt'
+end
+```
+
+Delete a certificate from the chain:
 
 ```ruby
 trusted_certificate 'my_corp' do

--- a/resources/trusted_certificate.rb
+++ b/resources/trusted_certificate.rb
@@ -33,7 +33,7 @@ action :create do
     cookbook_file "#{certificate_path}/#{new_resource.certificate_name}.crt" do
       sensitive new_resource.sensitive if new_resource.sensitive
       source src[-1]
-      cookbook (src.length == 2 ? src[0] : cookbook_name)
+      cookbook src.length == 2 ? src[0] : cookbook_name
       owner 'root'
       group 'staff' if platform_family?('debian')
       notifies :run, 'execute[update trusted certificates]'

--- a/spec/unit/trusted_certificate/content_spec.rb
+++ b/spec/unit/trusted_certificate/content_spec.rb
@@ -28,13 +28,13 @@ describe 'test::content' do
   end
 
   context 'compiling the recipe' do
-    it 'creates create_trusted_certificate[remote_content]' do
+    it 'creates trusted_certificate[remote_content]' do
       expect(centos_7).to create_trusted_certificate('remote_content')
     end
-    it 'creates create_trusted_certificate[cookbook_file_content]' do
+    it 'creates trusted_certificate[cookbook_file_content]' do
       expect(centos_7).to create_trusted_certificate('cookbook_file_content')
     end
-    it 'creates create_trusted_certificate[inline_content]' do
+    it 'creates trusted_certificate[inline_content]' do
       expect(centos_7).to create_trusted_certificate('inline_content')
     end
   end
@@ -48,7 +48,7 @@ describe 'test::content' do
           user: 'root'
         )
     end
-    it 'correctly certificates from remote_files' do
+    it 'correctly creates certificates from remote_files' do
       expect(centos_7).to create_remote_file('/etc/pki/ca-trust/source/anchors/remote_content.crt')
         .with(
           source: 'https://www.example.com/test',

--- a/spec/unit/trusted_certificate/content_spec.rb
+++ b/spec/unit/trusted_certificate/content_spec.rb
@@ -39,29 +39,29 @@ describe 'test::content' do
     end
   end
 
-   context 'stepping into chef_file' do
-     it 'correctly creates certificates from cookbook_files' do
-       expect(centos_7).to create_cookbook_file('/etc/pki/ca-trust/source/anchors/cookbook_file_content.crt')
-         .with(
-           source: 'testfile',
-           cookbook: 'test',
-           user: 'root',
-         )
-     end
-     it 'correctly certificates from remote_files' do
-       expect(centos_7).to create_remote_file('/etc/pki/ca-trust/source/anchors/remote_content.crt')
-         .with(
-           source: 'https://www.example.com/test',
-           user: 'root',
-         )
-     end
-     it 'correctly creates certificates from inline content' do
-       expect(centos_7).to create_file('/etc/pki/ca-trust/source/anchors/inline_content.crt')
-         .with(
-           content: "--------------BEGIN CERTIFICATE---------------------\nfobarbizabaz",
-           user: 'root',
-         )
-       expect(centos_7).to render_file('/etc/pki/ca-trust/source/anchors/inline_content.crt').with_content("--------------BEGIN CERTIFICATE---------------------\nfobarbizabaz")
-     end 
-   end
+  context 'stepping into chef_file' do
+    it 'correctly creates certificates from cookbook_files' do
+      expect(centos_7).to create_cookbook_file('/etc/pki/ca-trust/source/anchors/cookbook_file_content.crt')
+        .with(
+          source: 'testfile',
+          cookbook: 'test',
+          user: 'root'
+        )
+    end
+    it 'correctly certificates from remote_files' do
+      expect(centos_7).to create_remote_file('/etc/pki/ca-trust/source/anchors/remote_content.crt')
+        .with(
+          source: 'https://www.example.com/test',
+          user: 'root'
+        )
+    end
+    it 'correctly creates certificates from inline content' do
+      expect(centos_7).to create_file('/etc/pki/ca-trust/source/anchors/inline_content.crt')
+        .with(
+          content: "--------------BEGIN CERTIFICATE---------------------\nfobarbizabaz",
+          user: 'root'
+        )
+      expect(centos_7).to render_file('/etc/pki/ca-trust/source/anchors/inline_content.crt').with_content("--------------BEGIN CERTIFICATE---------------------\nfobarbizabaz")
+    end
+  end
 end

--- a/spec/unit/trusted_certificate/content_spec.rb
+++ b/spec/unit/trusted_certificate/content_spec.rb
@@ -1,0 +1,67 @@
+#
+# Cookbook:: trusted_certificate
+# Spec:: content
+#
+# Copyright 2016 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'test::content' do
+  cached(:centos_7) do
+    ChefSpec::ServerRunner.new(
+      step_into: 'trusted_certificate',
+      platform: 'centos',
+      version: '7.3.1611'
+    ).converge(described_recipe)
+  end
+
+  context 'compiling the recipe' do
+    it 'creates create_trusted_certificate[remote_content]' do
+      expect(centos_7).to create_trusted_certificate('remote_content')
+    end
+    it 'creates create_trusted_certificate[cookbook_file_content]' do
+      expect(centos_7).to create_trusted_certificate('cookbook_file_content')
+    end
+    it 'creates create_trusted_certificate[inline_content]' do
+      expect(centos_7).to create_trusted_certificate('inline_content')
+    end
+  end
+
+   context 'stepping into chef_file' do
+     it 'correctly creates certificates from cookbook_files' do
+       expect(centos_7).to create_cookbook_file('/etc/pki/ca-trust/source/anchors/cookbook_file_content.crt')
+         .with(
+           source: 'testfile',
+           cookbook: 'test',
+           user: 'root',
+         )
+     end
+     it 'correctly certificates from remote_files' do
+       expect(centos_7).to create_remote_file('/etc/pki/ca-trust/source/anchors/remote_content.crt')
+         .with(
+           source: 'https://www.example.com/test',
+           user: 'root',
+         )
+     end
+     it 'correctly creates certificates from inline content' do
+       expect(centos_7).to create_file('/etc/pki/ca-trust/source/anchors/inline_content.crt')
+         .with(
+           content: "--------------BEGIN CERTIFICATE---------------------\nfobarbizabaz",
+           user: 'root',
+         )
+       expect(centos_7).to render_file('/etc/pki/ca-trust/source/anchors/inline_content.crt').with_content("--------------BEGIN CERTIFICATE---------------------\nfobarbizabaz")
+     end 
+   end
+end

--- a/test/fixtures/cookbooks/test/recipes/content.rb
+++ b/test/fixtures/cookbooks/test/recipes/content.rb
@@ -1,0 +1,14 @@
+trusted_certificate 'remote_content' do
+  content 'https://www.example.com/test'
+  action :create
+end
+
+trusted_certificate 'cookbook_file_content' do
+  content 'cookbook_file://test::testfile'
+  action :create
+end
+
+trusted_certificate 'inline_content' do
+  content "--------------BEGIN CERTIFICATE---------------------\nfobarbizabaz"
+  action :create
+end


### PR DESCRIPTION
### Description

This change enables users to install a trusted cert that is provided either via URL or `cookbook_file` in a wrapper cookbook.

### Justification

We already have the certs in a standard format.  It's not a very good user experience (and introduces surfaces for opaque failure) to require users to take the standard cert format and convert it to a JSON encoded string...  To use this we were basically taking the output of this command:

```
ruby -rjson -e 'puts File.read(ARGV.shift).to_json' my_cert.crt
```

Then copy/pasting the result into an attribute.  

On more than one occasion obscure failures were caused due to a copy/paste error.

Being able to just use the file directly by copying it into the cookbook or downloading it from a known safe URL would eliminate the potential for human error in copy/pasting.

### Issues Resolved

N/A, well, this one :) (#16 )

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
