### PR TITLE
Fixes license issue and removes deprecation warnings

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -9,6 +9,7 @@ transport:
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manages adding certificates to the OS trust store'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+
 version '3.2.0'
 
 %w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon zlinux).each do |os|
@@ -12,4 +12,4 @@ end
 
 source_url 'https://github.com/chef-cookbooks/trusted_certificate'
 issues_url 'https://github.com/chef-cookbooks/trusted_certificate/issues'
-chef_version '>= 12.7' if respond_to?(:chef_version)
+chef_version '>= 12.7'

--- a/spec/unit/trusted_certificate/content_spec.rb
+++ b/spec/unit/trusted_certificate/content_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: trusted_certificate
 # Spec:: content
 #
-# Copyright 2016 Chef Software Inc
+# Copyright:: 2016 Chef Software Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ describe 'test::content' do
     ChefSpec::ServerRunner.new(
       step_into: 'trusted_certificate',
       platform: 'centos',
-      version: '7.3.1611'
+      version: '7'
     ).converge(described_recipe)
   end
 


### PR DESCRIPTION
This commit adds in the accept license for the kitchen dokken tests and
corrects the deprecation warning for the rspec tests.

Obvious fix.

### Description

Tests are failing on travis because of the chef license not being accepted.

### Issues Resolved

https://github.com/chef-cookbooks/trusted_certificate/issues/21

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [na] New functionality includes testing.
- [na] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
